### PR TITLE
Enable Issue Template Picker by Adding Templates and Adding Configuration File

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,70 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[Bug]: '
+labels: bug
+assignees: ''
+
+---
+
+# Bug Report
+<!-- A clear and concise description of the issue. -->
+
+---
+
+## To Reproduce
+<!-- Provide the YAML configuration and the exact CLI command that reproduces the issue. -->
+
+### YAML configuration
+<!-- Paste the YAML file or the smallest excerpt that reproduces the issue.
+Remove unrelated fields to make it minimal. -->
+```yaml
+# Paste the YAML snippet here
+```
+
+### CLI command used
+<!-- Write the exact command used, for example:   -->
+```bash
+# Paste the CLI command here
+```
+
+### Actual output
+<!-- Paste the output, logs, or error messages here -->
+```bash
+# Paste the output, logs, or error messages here
+```
+
+### Expected output
+<!-- Describe what you expected to see instead -->
+
+---
+
+## Environment and Versions
+
+- Operating System:
+- Package Version:
+- Python Version:
+- Package list:
+  - If using conda, run: `conda list > packages.txt` and paste the contents here.
+
+    ``` bash
+    # Paste packages.txt here
+    ```
+
+  - If using venv/pip, run: `pip list > packages.txt` and paste the contents here.
+
+    ``` bash
+    # Paste packages.txt here
+    ```
+
+---
+
+## Screenshots or Logs
+
+<!-- Attach any relevant screenshots, logs, or stack traces. -->
+
+---
+
+## Additional Context
+
+<!-- Include anything else that might help reproduce or understand the bug, such as changes from a previously working version. -->

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,22 @@
+blank_issues_enabled: false
+issue_templates:
+  - name: "Bug Report"
+    description: "Report a bug."
+    title: "[Bug]: "
+    labels: ["bug"]
+    body: "./ISSUE_TEMPLATE/bug_report.md"
+  - name: "Feature Request"
+    description: "Propose a new feature or improvement."
+    title: "[Feature]: "
+    labels: ["enhancement"]
+    body: "./ISSUE_TEMPLATE/feature_request.md"
+  - name: "Documentation"
+    description: "Suggest updates or additions to the documentation."
+    title: "[Docs]: "
+    labels: ["documentation"]
+    body: "./ISSUE_TEMPLATE/documentation.md"
+  - name: "General Report"
+    description: "Provide general feedback or inquiries."
+    title: "[General]: "
+    labels: ["general"]
+    body: "./ISSUE_TEMPLATE/general_report.md"

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,19 @@
+---
+name: Documentation
+about: Suggest updates or additions to documentation
+title: "[Docs]: "
+labels: documentation
+assignees: ''
+---
+
+### Documentation Update
+<!-- What part of the documentation needs to be updated or added? -->
+
+### Why Is This Needed?
+<!-- Explain the importance of this update. -->
+
+### Suggested Changes
+<!-- Provide a detailed description of the changes. -->
+
+### Additional Context
+<!-- Include any related resources. -->

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea
+title: '[Feature]: '
+labels: 'enhancement'
+assignees: ''
+---
+
+# Feature Request
+
+## Problem / Motivation
+<!-- Describe the problem you want to solve or the motivation for this feature. -->
+
+## Proposed Solution
+<!-- Describe the feature you would like to see implemented. Include examples if applicable. -->
+
+## Alternatives Considered
+- <!-- Alternative 1 -->
+- <!-- Alternative 2 -->
+
+## Expected Impact
+<!-- How this feature would affect the codebase or workflow -->
+- <!-- Impact 1 -->
+- <!-- Impact 2 -->
+
+## Additional Context
+<!-- Add any other context, screenshots, or references for the feature request here. -->
+- <!-- Further context -->

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/general_report.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE/general_report.md
@@ -1,0 +1,13 @@
+---
+name: General Report
+about: Provide general feedback or inquiries
+title: "[General]: "
+labels: general
+assignees: ''
+---
+
+### Feedback or Inquiry
+<!-- Provide your feedback or inquiry. -->
+
+### Additional Information
+<!-- Add any other relevant details here. -->


### PR DESCRIPTION
## Summary
This PR introduces a set of GitHub issue templates. These changes improve the contributor experience by providing clearly structured options for reporting issues and requesting documentation updates.

## Changes
### Add issue templates for various report types
- Added structured templates to support clearer and more consistent issue reporting.
- Enables users to quickly choose the correct issue category.

### Add documentation issue template
- Introduced a dedicated template for documentation-related improvements or changes.
- Helps separate documentation issues from general or bug reports.

### Add general report issue template
- Added a template to capture issues or requests that do not fall under a specific category.
- Provides a fallback option for contributors.

## Impact
- Improves the contributor workflow by enabling GitHub’s issue template picker.
- Standardises and clarifies issue reporting across the repository.
- Reduces ambiguity and improves issue triage for maintainers.