### PR TITLE
Update `.gitignore` File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# debug information files
+*.dwo

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the PR's purpose here. -->
Currently the `.gitignore` is not stored at the root of the repository, this has now been brought back and a standard C++ `.gitignore` has been added.

## Changes
<!-- List all the changes introduced in this PR. -->
### Changes to `.gitignore`
- Moved from `SIST/.ideas/.gitignore` -> `SIST/.gitignore`
- Included standard C++ template

## Impact
- The `.gitignore` should function as intended in the correct location
- The standard C++ template should mean there isn't any accidental commits to the repository