### PR TITLE
Resolve Compiler Warnings for the SIST 1.0.0 Release

### DIFF
--- a/trans_compete/SIDD_3R.cpp
+++ b/trans_compete/SIDD_3R.cpp
@@ -126,8 +126,8 @@ bool SIDD_3R::Search_Low3RE()
             }
         }
 	}
-
-    if (results)
+	
+	if (results)
         cout << "Number of three-run states = " << count << endl;
 	StatesInThreeRuns = (long)count;
 	ZsumB += sum_3RB;

--- a/trans_compete/SIDD_4R.cpp
+++ b/trans_compete/SIDD_4R.cpp
@@ -70,8 +70,8 @@ bool SIDD_4R::Search_Low4RE()
 							if(Lst_OBE[n1][t1].begin()->get_energy() + min_RE[t2] + min_RE[t3]+ min_RE[t4] + minGres >= max_E)
 								continue;
 						for(int n2 = n1; n2 <= (window_size - n1)/3 ; n2++){
-							if (n1==n2 && t1==1 && t2==0) 
-								continue;
+                            if (n1==n2 && t1==1 && t2==0) 
+                                continue;
 								if(Lst_OBE[n1][t1].begin()->get_energy() + Lst_OBE[n2][t2].begin()->get_energy()+ min_RE[t3] + min_RE[t4] + minGres >= max_E)	
 									continue;
 							for(int n3 = n2; n3 <= (window_size - n1 - n2)/2; n3++){

--- a/trans_compete/SIDD_Base.cpp
+++ b/trans_compete/SIDD_Base.cpp
@@ -32,7 +32,7 @@ SIDD_Base::SIDD_Base()
     en_cruciforms = 0;
 	for (int t=0; t<=Ns; t++) {
 		profile[t] = 0;
-	for(int m = MinWindowSize; m <= MaxWindowSize; m++) {
+	for(int m = 0; m <= MaxInitialWindowSize; m++) {
 		promatrix[m][t] = 0;
 		}
 	}

--- a/trans_compete/SIDD_Base.cpp
+++ b/trans_compete/SIDD_Base.cpp
@@ -836,11 +836,11 @@ void SIDD_Base::calc_profile()
     // V: The following lines is just a search of the maximum Gx for each transition, to substitute the Infinite.
 	maxGx = profile[1][0].get_ave_Gx();
 	for(int t=0; t<=Ns; t++) {
-        for(int j = 1; j < length_seq; j++){
-            if(maxGx < profile[t][j].get_ave_Gx()){
-                maxGx = profile[t][j].get_ave_Gx(); // find max Gx
-            }
-        }
+		for(int j = 1; j < length_seq; j++){
+			if(maxGx < profile[t][j].get_ave_Gx()){
+				maxGx = profile[t][j].get_ave_Gx(); // find max Gx
+			}
+		}
 	}
     // V: This is for the substitution.
 	for(int t=0; t<=Ns; t++) {
@@ -860,11 +860,11 @@ void SIDD_Base::sum_open()
 			sumn[t]+=profile[t][i].get_px();	
 		}
 	}
-    if (results) {
-        cout << "N_Melting = " << sumn[0] << endl;
-        cout << "N_Z = " << sumn[1] << endl;
-        cout << "N_Cruciform = " << sumn[2] << endl;
-    }
+	if (results) {
+		cout << "N_Melting = " << sumn[0] << endl;
+		cout << "N_Z = " << sumn[1] << endl;
+		cout << "N_Cruciform = " << sumn[2] << endl;
+	}
 }
 
 void SIDD_Base::get_column_header() {

--- a/trans_compete/SIDD_Base.cpp
+++ b/trans_compete/SIDD_Base.cpp
@@ -246,8 +246,8 @@ double SIDD_Base::prepare_sequence(std::string sequence) {
 void SIDD_Base::prepare_cruciforms() {
     string str1 = cr_string;
     size_t found1 = 0;
-    int IR[2];
-    double energy;
+    int IR[2] = {0, 0};
+    double energy = 0.0;
     int pos1 = 0;
     int pos2 = 0;
     string str2;
@@ -276,15 +276,16 @@ void SIDD_Base::prepare_cruciforms() {
                 if(found2!=string::npos) {
                     str3 = str2.substr(pos2,found2-pos2);
                     pos2 = int(found2)+1;
-                    if (i==2) 
-                        energy=atof(str3.c_str());
-                    else 
+                    if (i == 2)
+                        energy = atof(str3.c_str());
+                    else if (i < 2)
                         IR[i] = atoi(str3.c_str());
                     i++;
                 }
             }
-            if (IR[1] <= MaxWindowSize)
-	    en_cruciforms[IR[0]-1][IR[1]] = energy;
+            if (i == 3 && IR[0] > 0 && IR[0] <= length_seq &&
+                IR[1] > 0 && IR[1] <= MaxWindowSize)
+                en_cruciforms[IR[0]-1][IR[1]] = energy;
             pos1 = int(found1)+1;
         }
     }

--- a/trans_compete/qsidd.cpp
+++ b/trans_compete/qsidd.cpp
@@ -161,13 +161,13 @@ int main(int argc, char* argv[])
 		cerr << "sidd.initializer failed" << endl;
 		exit(1);
 	}
-	if (sidd.get_Flag_PEA()) sidd.assign_pea(energy);
+    if (sidd.get_Flag_PEA()) sidd.assign_pea(energy);
     
     if (threshold < 9)
         cout << "WARNING: threshold is too small, results may be inaccurate"<< endl;
-	if (threshold > 15)
+    if (threshold > 15)
         cout << "WARNING: threshold is too high, execution time may be very long"<< endl;
-	if (stress_level > 0.15 || stress_level < -0.15)
+    if (stress_level > 0.15 || stress_level < -0.15)
         cout << "WARNING: superhelical density is outside of physiological range"<< endl;
     if (temperature < 220 || temperature > 320)
         cout << "WARNING: temperature is outside of physiological range"<< endl;

--- a/trans_three/SIDD_1R.cpp
+++ b/trans_three/SIDD_1R.cpp
@@ -90,7 +90,7 @@ bool SIDD_1R::Search_Low1RE()
 
     ZsumB = sum_1RB + closed;
  	ZsumG = sum_1RG+alpha*alpha*K/2*closed;
-    if (write_profile && results)
+	if (write_profile && results)
         cout << "Number of one-run states = " << count << endl;
 	return flag_minE1;
 }

--- a/trans_three/SIDD_2R.cpp
+++ b/trans_three/SIDD_2R.cpp
@@ -97,8 +97,8 @@ bool SIDD_2R::Search_Low2RE()
 	StatesInTwoRuns = count;
 	ZsumB += sum_2RB;
 	ZsumG +=sum_2RG;
-
-    if (results)
+	
+	if (results)
         cout << "Number of two-run states = " << count << endl;
 	return flag_minE2;
 }

--- a/trans_three/SIDD_3R.cpp
+++ b/trans_three/SIDD_3R.cpp
@@ -100,7 +100,7 @@ bool SIDD_3R::Search_Low3RE()
 			}
 		}
 	}
-    if (results)
+	if (results)
         cout << "Number of three-run states = " << count << endl;
 	StatesInThreeRuns = (long)count;
 	ZsumB += sum_3RB;

--- a/trans_three/SIDD_Base.cpp
+++ b/trans_three/SIDD_Base.cpp
@@ -837,17 +837,17 @@ void SIDD_Base::calc_profile()
 
 void SIDD_Base::sum_open()
 {
- double sumn=0.0;
- for(int i = 0; i < length_seq; i++)
-    sumn+=profile[i].get_px();
-    if (results) {
-        if (EnergyType == Z_DNA)
-            cout << "Number of Z-DNA bases = " << sumn << endl;
-        else if (EnergyType == Cruciform)
-            cout << "Number of cruciform bases = " << sumn << endl;
-        else
-            cout << "Number of melted bases = " << sumn << endl;
-    }
+	double sumn=0.0;
+	for(int i = 0; i < length_seq; i++)
+ 	sumn+=profile[i].get_px();
+	if (results) {
+		if (EnergyType == Z_DNA)
+			cout << "Number of Z-DNA bases = " << sumn << endl;
+		else if (EnergyType == Cruciform)
+			cout << "Number of cruciform bases = " << sumn << endl;
+		else
+			cout << "Number of melted bases = " << sumn << endl;
+	}
 }
 
 void SIDD_Base::get_column_header()
@@ -956,7 +956,7 @@ void SIDD_Base::show_parameter()
 		cout << "Energetics: Melting - nearest neighbor energetics\n";
 	else if (EnergyType == Z_DNA)
 		cout << "Transition: Z-DNA\n";
-    else if (EnergyType == Cruciform)
+	else if (EnergyType == Cruciform)
         cout << "Transition: Cruciform\n";
 	if(MoleculeType == Circular)
 		cout << "Molecule type: circular DNA\n";

--- a/trans_three/SIDD_Base.cpp
+++ b/trans_three/SIDD_Base.cpp
@@ -240,8 +240,8 @@ double SIDD_Base::prepare_sequence(std::string sequence) {
 void SIDD_Base::prepare_cruciforms() {
     string str1 = cr_string;
     size_t found1 = 0;
-    int IR[2];
-    double energy;
+    int IR[2] = {0, 0};
+    double energy = 0.0;
     int pos1 = 0;
     int pos2 = 0;
     string str2;
@@ -267,15 +267,16 @@ void SIDD_Base::prepare_cruciforms() {
                 if(found2!=string::npos) {
                     str3 = str2.substr(pos2,found2-pos2);
                     pos2 = int(found2)+1;
-                    if (i==2) 
-                        energy=atof(str3.c_str());
-                    else 
+                    if (i == 2)
+                        energy = atof(str3.c_str());
+                    else if (i < 2)
                         IR[i] = atoi(str3.c_str());
                     i++;
                 }
             }
-            if (IR[1] <= MaxWindowSize)
-		en_cruciforms[IR[0]-1][IR[1]] = energy;
+            if (i == 3 && IR[0] > 0 && IR[0] <= length_seq &&
+                IR[1] > 0 && IR[1] <= MaxWindowSize)
+                en_cruciforms[IR[0]-1][IR[1]] = energy;
             pos1 = int(found1)+1;
         }
     }

--- a/trans_three/SIDD_Base.cpp
+++ b/trans_three/SIDD_Base.cpp
@@ -32,7 +32,7 @@ SIDD_Base::SIDD_Base()
 	plasmid_seq = 0; 
 	en_cruciforms = 0;
 	profile = 0;
-	for(int m = MinWindowSize; m <= MaxWindowSize; m++)
+	for(int m = 0; m <= MaxInitialWindowSize; m++)
 		promatrix[m] = 0;
 	R = 8.314/(4.2*1000.0); // gas constant
 	C = 3.6; // stiffness constant 

--- a/trans_three/qsidd.cpp
+++ b/trans_three/qsidd.cpp
@@ -160,10 +160,10 @@ int main(int argc, char* argv[])
         }
         sidd.set_Flag_PEA(energy);
 	}
-	
-	if (!sidd.initializer(dnasequence.str().c_str(),length)) {
+    
+    if (!sidd.initializer(dnasequence.str().c_str(),length)) {
 		cerr << "sidd.initializer failed" << endl;
-		exit(1);
+        exit(1);
 	}
     if (sidd.get_Flag_PEA()) sidd.assign_pea(energy);
 
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
         cout << "WARNING: threshold is too small, results may be inaccurate"<< endl;
     if (threshold > 15)
         cout << "WARNING: threshold is too high, execution time may be very long"<< endl;
-	if (stress_level > 0.15 || stress_level < -0.15)
+    if (stress_level > 0.15 || stress_level < -0.15)
         cout << "WARNING: superhelical density is outside of physiological range"<< endl;
     if (temperature < 220 || temperature > 320)
         cout << "WARNING: temperature is outside of physiological range"<< endl;


### PR DESCRIPTION
## Summary
Resolve compiler warnings identified while preparing SIST for the 1.0.0 release.

The changes remove uninitialised state and clarify ambiguous control flow while keeping the existing scientific behaviour as close as possible to the current implementation.

## Changes
### Initialisation fixes:
- Avoid using uninitialised `MinWindowSize` and `MaxWindowSize` values in the constructors.
- Initialise profile matrix pointers using the fixed `MaxInitialWindowSize` bounds.

### Cruciform record validation:
- Initialise cruciform record values before use.
- Only store complete and valid cruciform energy records.
- Prevent malformed records from accessing invalid sequence positions.

### Compiler warning cleanup:
- Resolve misleading-indentation warnings in `trans_three` and `trans_compete`.
- Make existing control flow explicit without intentionally changing behaviour.

## Impact

- Both `trans_three` and `trans_compete` build cleanly
- Removes identified uninitialised-state and ambiguous-control-flow warnings.
- No intentional changes to scientific parameters, defaults, or supported calculations.